### PR TITLE
fix deprecation in blueprint

### DIFF
--- a/blueprints/ember-pop-over/index.js
+++ b/blueprints/ember-pop-over/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   normalizeEntityName: function() {},
   afterInstall: function() {
-    return this.addBowerPackageToProject('dom-ruler#0.1.13');
+    return this.addBowerPackageToProject('dom-ruler', '0.1.13');
   }
 };


### PR DESCRIPTION
This fixes a deprecation warning:

```
DEPRECATION: passing dom-ruler#0.1.5 directly to `addBowerPackageToProject` will soon be unsupported.
```
