### PR TITLE
Fixing race condition with observer.

### DIFF
--- a/addon/components/pop-over.js
+++ b/addon/components/pop-over.js
@@ -10,6 +10,7 @@ const observer = Ember.observer;
 const bind = Ember.run.bind;
 const scheduleOnce = Ember.run.scheduleOnce;
 const next = Ember.run.next;
+const once = Ember.run.once;
 
 const get = Ember.get;
 const set = Ember.set;
@@ -219,22 +220,23 @@ export default Ember.Component.extend({
     menu.
    */
   visibilityDidChange: on('init', observer('areAnyTargetsActive', function () {
-    var proxy = this.__documentClick = this.__documentClick || bind(this, 'documentClick');
+    once(() => {
+      var proxy = this.__documentClick = this.__documentClick || bind(this, 'documentClick');
+      var active = get(this, 'areAnyTargetsActive');
+      var inactive = !active;
+      var visible = get(this, 'active');
+      var hidden = !visible;
 
-    var active = get(this, 'areAnyTargetsActive');
-    var inactive = !active;
-    var visible = get(this, 'active');
-    var hidden = !visible;
+      if (active && hidden) {
+        $(document).on('mousedown', proxy);
+        this.show();
 
-    if (active && hidden) {
-      $(document).on('mousedown', proxy);
-      this.show();
-
-    // Remove click events immediately
-    } else if (inactive && visible) {
-      $(document).off('mousedown', proxy);
-      this.hide();
-    }
+      // Remove click events immediately
+      } else if (inactive && visible) {
+        $(document).off('mousedown', proxy);
+        this.hide();
+      }
+    });
   })),
 
   hide() {


### PR DESCRIPTION
Fixes #15 

Apologies for the other PR. I went down a rabbit hole with merging the component into an `if / else` without really grokking what the whole `pop-over-hidden` thing was about. The root cause of this can be found in #15. 

Simplified explanation is that when an observer utlizes a computed property, it creates a race condition. Solution is to wrap the contents of the observer in an `Ember.run.once`.
