### PR TITLE
When using liquid fire, .pop-over is always present after initial display

### DIFF
--- a/app/templates/components/pop-over.hbs
+++ b/app/templates/components/pop-over.hbs
@@ -1,5 +1,5 @@
 {{#if supportsLiquidFire}}
-  <div class="pop-over-compass">
+  <div class="pop-over-compass {{unless active "pop-over-compass-invisible"}}">
     {{#liquid-if active class="liquid-pop-over"}}
       <div class="pop-over-container">
         <span class="pop-over-pointer orient-{{orientation}}"></span>

--- a/vendor/styles/ember-popup-menu.css
+++ b/vendor/styles/ember-popup-menu.css
@@ -7,6 +7,10 @@
   z-index: 100;
 }
 
+.pop-over-compass-invisible {
+  visibility: hidden;
+}
+
 .liquid-pop-over {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
After displaying the first time, the pop-over element is always in the DOM and can obstruct other elements on the page by covering them.
