### PR TITLE
Fix opening pop-over on ios touch devices

### DIFF
--- a/addon/components/pop-over.js
+++ b/addon/components/pop-over.js
@@ -142,7 +142,7 @@ export default Ember.Component.extend({
     });
 
     if (this.__documentClick) {
-      $(document).off('mousedown', this.__documentClick);
+      $(document).off('mousedown touchstart', this.__documentClick);
       this.__documentClick = null;
     }
 
@@ -186,6 +186,12 @@ export default Ember.Component.extend({
     if (!clicked && !clickedAnyTarget) {
       targets.setEach('pressed', false);
     }
+
+    if (clickedAnyTarget && evt.type === 'touchstart') {
+      // don't allow touch devices to trigger mouseDown
+      evt.stopPropagation();
+      evt.preventDefault();
+    }
   },
 
   areAnyTargetsActive: bool('activeTargets.length'),
@@ -228,12 +234,12 @@ export default Ember.Component.extend({
       var hidden = !visible;
 
       if (active && hidden) {
-        $(document).on('mousedown', proxy);
+        $(document).on('mousedown touchstart', proxy);
         this.show();
 
       // Remove click events immediately
       } else if (inactive && visible) {
-        $(document).off('mousedown', proxy);
+        $(document).off('mousedown touchstart', proxy);
         this.hide();
       }
     });

--- a/addon/system/target.js
+++ b/addon/system/target.js
@@ -107,7 +107,8 @@ var Target = Ember.Object.extend(Ember.Evented, {
       focusout:   bind(this, 'blur'),
       mouseenter: bind(this, 'mouseEnter'),
       mouseleave: bind(this, 'mouseLeave'),
-      mousedown:  bind(this, 'mouseDown')
+      mousedown:  bind(this, 'mouseDown'),
+      touchstart:  bind(this, 'mouseDown')
     };
 
     if (get(target, 'element')) {
@@ -267,7 +268,7 @@ var Target = Ember.Object.extend(Ember.Evented, {
 
       var eventManager = this.eventManager;
       eventManager.mouseup = bind(this, 'mouseUp');
-      $(document).on('mouseup', eventManager.mouseup);
+      $(document).on('mouseup touchend', eventManager.mouseup);
 
       evt.preventDefault();
     }
@@ -279,7 +280,7 @@ var Target = Ember.Object.extend(Ember.Evented, {
   mouseUp: function (evt) {
     // Remove mouseup event
     var eventManager = this.eventManager;
-    $(document).off('mouseup', eventManager.mouseup);
+    $(document).off('mouseup touchend', eventManager.mouseup);
     eventManager.mouseup = null;
 
     var label = labelForEvent(evt);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-pop-over",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "A constraint-based pop-over component for ember apps",
   "directories": {
     "doc": "doc",

--- a/tests/acceptance/events-test.js
+++ b/tests/acceptance/events-test.js
@@ -3,6 +3,8 @@ import startApp from '../helpers/start-app';
 import mouseUp from '../helpers/mouse-up';
 import simpleClick from '../helpers/simple-click';
 import mouseDown from '../helpers/mouse-down';
+import touchStart from '../helpers/touch-start';
+import touchEnd from '../helpers/touch-end';
 import mouseEnter from '../helpers/mouse-enter';
 import mouseLeave from '../helpers/mouse-leave';
 import focus from '../helpers/focus';
@@ -21,7 +23,7 @@ module('Acceptance: Events', {
 });
 
 test('on="click"', function() {
-  expect(6);
+  expect(9);
   visit('/');
 
   simpleClick("#click");
@@ -59,10 +61,33 @@ test('on="click"', function() {
   andThen(function () {
     ok(find(".pop-over-container:visible").length === 1);
   });
+
+  simpleClick("#click");
+  andThen(function () {
+    ok(find(".pop-over-container:visible").length === 0);
+  });
+
+  touchStart("#click");
+  andThen(function () {
+    ok(find(".pop-over-container:visible").length === 1);
+  });
+
+  andThen(function () {
+    var defer = Ember.RSVP.defer();
+    later(defer, 'resolve', 400);
+    return defer.promise;
+  });
+
+  touchEnd("#click");
+  andThen(function () {
+    ok(find(".pop-over-container:visible").length === 1);
+  });
+
+
 });
 
 test('on="click hold"', function() {
-  expect(4);
+  expect(6);
   visit('/');
 
   mouseDown("#click-hold");
@@ -77,6 +102,22 @@ test('on="click hold"', function() {
   });
 
   mouseUp("#click-hold");
+  andThen(function () {
+    ok(find(".pop-over-container:visible").length === 0);
+  });
+
+  touchStart("#click-hold");
+  andThen(function () {
+    ok(find(".pop-over-container:visible").length === 1);
+  });
+
+  andThen(function () {
+    var defer = Ember.RSVP.defer();
+    later(defer, 'resolve', 400);
+    return defer.promise;
+  });
+
+  touchStop("#click-hold");
   andThen(function () {
     ok(find(".pop-over-container:visible").length === 0);
   });

--- a/tests/helpers/touch-end.js
+++ b/tests/helpers/touch-end.js
@@ -1,0 +1,3 @@
+export default function (selector) {
+  triggerEvent(selector, "touchend");
+}

--- a/tests/helpers/touch-start.js
+++ b/tests/helpers/touch-start.js
@@ -1,0 +1,3 @@
+export default function (selector) {
+  triggerEvent(selector, "touchstart");
+}


### PR DESCRIPTION
Safari on iPhone and iPad doesn't trigger `mouseDown` `mouseUp` events.

This fix adds event listeners for `touchStart` and `touchEnd`.
