### PR TITLE
include popover keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "keywords": [
     "ember-addon",
-    "pop-over"
+    "pop-over",
+    "popover"
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3"


### PR DESCRIPTION
I didn't see this addon listed during my initial search for "popover". Thought it might come in handy for others to add an npm keyword for "popover".
