### PR TITLE
Use unshiftObject for inserting single contraint

### DIFF
--- a/addon/system/orientation.js
+++ b/addon/system/orientation.js
@@ -68,7 +68,7 @@ export default Ember.Object.extend({
 
     // Always unshift slide constraints,
     // since they should be handled first
-    get(this, 'constraints').unshiftObjects(constraint);
+    get(this, 'constraints').unshiftObject(constraint);
 
     return this;
   },


### PR DESCRIPTION
In upgrading our app to Ember 2.18 the call to `unshiftObjects` with a single value (instead of an array) as the arg results in an error: `The third argument to replace needs to be an array.`

I am not really clear on why this is only erroring with this upgrade but I suspect that the internals of ember-metal or ember-runtime have be rearranged in some manner such that the `replace` method that `unshiftObjects` delegates to is now less permissive.